### PR TITLE
[Fix] Win error code

### DIFF
--- a/platformScripts/shell/windows/inferSystemVariables.sh
+++ b/platformScripts/shell/windows/inferSystemVariables.sh
@@ -56,6 +56,7 @@ function runNative {
     cmd << EOD
 call $varsetupcommand
 ${@}
+%COMSPEC% /C exit %ERRORLEVEL% >nul
 EOD
 }
 

--- a/platformScripts/shell/windows/inferSystemVariables.sh
+++ b/platformScripts/shell/windows/inferSystemVariables.sh
@@ -56,7 +56,7 @@ function runNative {
     cmd << EOD
 call $varsetupcommand
 ${@}
-%COMSPEC% /C exit %ERRORLEVEL% >nul
+exit /b %errorlevel%
 EOD
 }
 


### PR DESCRIPTION
We did not exit in the cmd call correctly.
This is fixed now and returns the correct error code to the shell.